### PR TITLE
Remove nokogiri version upper limit

### DIFF
--- a/lib/twemoji/version.rb
+++ b/lib/twemoji/version.rb
@@ -1,3 +1,3 @@
 module Twemoji
-  VERSION = "1.1.0"
+  VERSION = "3.1.5"
 end

--- a/lib/twemoji/version.rb
+++ b/lib/twemoji/version.rb
@@ -1,3 +1,3 @@
 module Twemoji
-  VERSION = "3.1.5"
+  VERSION = "1.1.0"
 end

--- a/twemoji.gemspec
+++ b/twemoji.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = %w(lib)
 
-  spec.add_dependency "nokogiri", [">= 1.4", "< 1.9"]
+  spec.add_dependency "nokogiri", [">= 1.4"]
 end


### PR DESCRIPTION
#### Addresses:
https://app.clubhouse.io/dailykos/story/3525/upgrade-nokogiri-to-1-10-4

#### Notes:
- removes upper limit for nokogiri gem
- allows upgrade to nokogiri